### PR TITLE
[patterns] Add wireless-regdb dependency for WiFi/BT module

### DIFF
--- a/patterns/jolla-hw-adaptation-dontbeevil.yaml
+++ b/patterns/jolla-hw-adaptation-dontbeevil.yaml
@@ -81,5 +81,8 @@ Requires:
 # For devices with SD Card
 #- sd-utils
 
+# WiFi/BT regulator DB
+- wireless-regdb
+
 Summary: Jolla HW Adaptation dontbeevil
 


### PR DESCRIPTION
This PR will add the wireless-regdb package to the hw patterns.
This fixes the missing regulator database for the WiFi/BT module.