### PR TITLE
[config] Added GPS configuration

### DIFF
--- a/sparse/etc/default/gpsd
+++ b/sparse/etc/default/gpsd
@@ -1,0 +1,1 @@
+DEVICES=/dev/EC25.NMEA

--- a/sparse/etc/gpsd/device-hook
+++ b/sparse/etc/gpsd/device-hook
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Device hook script to enable and disable the EC25 modem GPS
+# Based on: https://zedm.net/archives/tag/device-hook
+# This script needs to be owned by root and be accessible from the dialout group with permissions 750.
+#
+if [ "$1" = "/dev/EC25.NMEA" ] && [ "$2" = "ACTIVATE" ];
+then
+        echo "AT+QGPS=1" > "/dev/EC25.AT"
+        sleep 5
+else
+        if [ "$1" = "/dev/EC25.NMEA" ] && [ "$2" = "DEACTIVATE" ];
+        then
+        echo "AT+QGPS=0" > "/dev/EC25.AT"
+        fi
+fi

--- a/sparse/usr/lib/udev/rules.d/20-modem-ec25.rules
+++ b/sparse/usr/lib/udev/rules.d/20-modem-ec25.rules
@@ -1,0 +1,3 @@
+SUBSYSTEMS=="usb", KERNEL=="ttyUSB[0-9]*", ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="0125", ENV{.LOCAL_ifNum}=="01", SYMLINK+="EC25.NMEA", MODE="0660"
+SUBSYSTEMS=="usb", KERNEL=="ttyUSB[0-9]*", ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="0125", ENV{.LOCAL_ifNum}=="02", SYMLINK+="EC25.AT", MODE="0660"
+SUBSYSTEMS=="usb", KERNEL=="ttyUSB[0-9]*", ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="0125", ENV{.LOCAL_ifNum}=="03", SYMLINK+="EC25.MODEM", MODE="0660"


### PR DESCRIPTION
Points `gpsd` to the right USB device (`/dev/EC25.NMEA`) of the modem.
You need the `udev` rules for this to achieve it.

To start the GPS NMEA interface, a `systemd` service is triggered before starting `gpsd` which sends the following AT command: `AT+QGPS=1` to `/dev/EC25.AT`.

Fixes https://github.com/sailfish-on-dontbeevil/issues-dontbeevil/issues/5