### PR TITLE
[config] Added ofono configuration for the QMI modem EC25

### DIFF
--- a/sparse/var/lib/environment/ofono/noplugin.conf
+++ b/sparse/var/lib/environment/ofono/noplugin.conf
@@ -1,0 +1,31 @@
+# The EC25 QMI modem requires the following plugins in ofono: 
+#   - udev and udevng for detecting the modem
+#   - qmimodem and gobi for sending commands to the modem
+OFONO_ARGS="--noplugin=\
+,he910\
+,dun_gw_bluez5\
+,hfp_bluez5\
+,hfp_ag_bluez5\
+,cdma_provision\
+,bluez5\
+,isimodem\
+,n900\
+,u8500\
+,cdmamodem\
+,isiusb\
+,nwmodem\
+,ztemodem\
+,iceramodem\
+,huaweimodem\
+,calypsomodem\
+,swmodem\
+,mbmmodem\
+,hsomodem\
+,ifxmodem\
+,stemodem\
+,dunmodem\
+,hfpmodem\
+,speedupmodem\
+,phonesim\
+,telitmodem \
+--plugin=udev,udevng,qmimodem,gobi"

--- a/sparse/var/lib/environment/ofono/noplugin.conf
+++ b/sparse/var/lib/environment/ofono/noplugin.conf
@@ -27,5 +27,7 @@ OFONO_ARGS="--noplugin=\
 ,hfpmodem\
 ,speedupmodem\
 ,phonesim\
+,rilmodem\
+,ril\
 ,telitmodem \
 --plugin=udev,udevng,qmimodem,gobi"


### PR DESCRIPTION
The EC25 QMI modem requires the following plugins in ofono: 
- `udev` and `udevng` for detecting the modem
- `qmimodem` and `gobi` for sending commands to the modem

Thanks to SuperPrower for the help/figuring it out!

Wiki information: https://wiki.merproject.org/wiki/Adaptations/PinePhone64#Modem_EC25

Fixes https://github.com/sailfish-on-dontbeevil/issues-dontbeevil/issues/1