### PR TITLE
[config] Added PulseAudio config for native A64 sound card using ALSA

### DIFF
--- a/sparse/etc/pulse/arm_native_default.pa
+++ b/sparse/etc/pulse/arm_native_default.pa
@@ -1,0 +1,140 @@
+#!/usr/bin/pulseaudio -nF
+#
+# This file is part of PulseAudio.
+#
+# PulseAudio is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# PulseAudio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with PulseAudio; if not, see <http://www.gnu.org/licenses/>.
+
+# This startup script is used only if PulseAudio is started per-user
+# (i.e. not in system mode)
+
+.fail
+
+### Automatically restore the volume of streams and devices
+load-module module-device-restore
+load-module module-stream-restore
+load-module module-card-restore
+
+### Automatically augment property information from .desktop files
+### stored in /usr/share/application
+load-module module-augment-properties
+
+### Should be after module-*-restore but before module-*-detect
+load-module module-switch-on-port-available
+
+### Load audio drivers statically
+### (it's probably better to not load these drivers manually, but instead
+### use module-udev-detect -- see below -- for doing this automatically)
+load-module module-alsa-sink
+load-module module-alsa-source device=hw:1,0
+#load-module module-oss device="/dev/dsp" sink_name=output source_name=input
+#load-module module-oss-mmap device="/dev/dsp" sink_name=output source_name=input
+#load-module module-null-sink
+#load-module module-pipe-sink
+
+### Automatically load driver modules depending on the hardware available
+.ifexists module-udev-detect.so
+load-module module-udev-detect
+.else
+### Use the static hardware detection module (for systems that lack udev support)
+load-module module-detect
+.endif
+
+### Automatically connect sink and source if JACK server is present
+.ifexists module-jackdbus-detect.so
+.nofail
+load-module module-jackdbus-detect channels=2
+.fail
+.endif
+
+### Automatically load driver modules for Bluetooth hardware
+.ifexists module-bluetooth-policy.so
+load-module module-bluetooth-policy
+.endif
+
+.ifexists module-bluetooth-discover.so
+load-module module-bluetooth-discover
+.endif
+
+### Load several protocols
+.ifexists module-esound-protocol-unix.so
+load-module module-esound-protocol-unix
+.endif
+load-module module-native-protocol-unix
+
+### Network access (may be configured with paprefs, so leave this commented
+### here if you plan to use paprefs)
+#load-module module-esound-protocol-tcp
+#load-module module-native-protocol-tcp
+
+### Load the RTP receiver module (also configured via paprefs, see above)
+#load-module module-rtp-recv
+
+### Load the RTP sender module (also configured via paprefs, see above)
+#load-module module-null-sink sink_name=rtp format=s16be channels=2 rate=44100 sink_properties="device.description='RTP Multicast Sink'"
+#load-module module-rtp-send source=rtp.monitor
+
+### Load additional modules from GSettings. This can be configured with the paprefs tool.
+### Please keep in mind that the modules configured by paprefs might conflict with manually
+### loaded modules.
+.ifexists module-gsettings.so
+.nofail
+load-module module-gsettings
+.fail
+.endif
+
+
+### Automatically restore the default sink/source when changed by the user
+### during runtime
+### NOTE: This should be loaded as early as possible so that subsequent modules
+### that look up the default sink/source get the right value
+load-module module-default-device-restore
+
+### Automatically move streams to the default sink if the sink they are
+### connected to dies, similar for sources
+load-module module-rescue-streams
+
+### Make sure we always have a sink around, even if it is a null sink.
+load-module module-always-sink
+
+### Honour intended role device property
+load-module module-intended-roles
+
+### Automatically suspend sinks/sources that become idle for too long
+load-module module-suspend-on-idle
+
+### If autoexit on idle is enabled we want to make sure we only quit
+### when no local session needs us anymore.
+.ifexists module-console-kit.so
+load-module module-console-kit
+.endif
+.ifexists module-systemd-login.so
+load-module module-systemd-login
+.endif
+
+### Enable positioned event sounds
+load-module module-position-event-sounds
+
+### Cork music/video streams when a phone stream is active
+load-module module-role-cork
+
+### Modules to allow autoloading of filters (such as echo cancellation)
+### on demand. module-filter-heuristics tries to determine what filters
+### make sense, and module-filter-apply does the heavy-lifting of
+### loading modules and rerouting streams.
+load-module module-filter-heuristics
+load-module module-filter-apply
+
+### Make some devices default
+#set-default-sink output
+#set-default-source input

--- a/sparse/etc/sysconfig/pulseaudio
+++ b/sparse/etc/sysconfig/pulseaudio
@@ -1,0 +1,1 @@
+CONFIG="-n --file=/etc/pulse/arm_native_default.pa"

--- a/sparse/etc/systemd/system/sound.target.wants/unmute-sound-card.service
+++ b/sparse/etc/systemd/system/sound.target.wants/unmute-sound-card.service
@@ -1,0 +1,1 @@
+../../../lib/systemd/system/unmute-sound-card.service

--- a/sparse/lib/systemd/system/unmute-sound-card.service
+++ b/sparse/lib/systemd/system/unmute-sound-card.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Unmutes the A64 sound card at boot for PulseAudio
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/droid/unmute-sound-card.sh
+
+[Install]
+WantedBy=sound.target

--- a/sparse/usr/bin/droid/unmute-sound-card.sh
+++ b/sparse/usr/bin/droid/unmute-sound-card.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Unmute the A64 sound card at boot
+
+amixer -c 0 set 'AIF1 Slot 0 Digital DAC' unmute


### PR DESCRIPTION
Removed the `arm_droid_default.pa` PulseAudio config as default one and replaced it by our native configuration. Native config is based on the `default.pa` config with ALSA modules enabled.

By default, the ALSA sound card is muted, will be fixed in another PR.

Playing ringtones from the Settings app works after unmuting `AIF1 Slot 0 Digital DAC` with `alsamixer`.

Fixed https://github.com/sailfish-on-dontbeevil/issues-dontbeevil/issues/2