### PR TITLE
[config] Added sensorfw configuration

### DIFF
--- a/sparse/etc/sensorfw/primaryuse.conf
+++ b/sparse/etc/sensorfw/primaryuse.conf
@@ -1,0 +1,7 @@
+[plugins]
+accelerometeradaptor = iiosensorsadaptor
+orientationadaptor = iiosensorsadaptor
+alsadaptor = iiosensorsadaptor
+magnetometeradaptor = iiosensorsadaptor
+gyroscopeadaptor = iiosensorsadaptor
+proximityadaptor = iiosensorsadaptor

--- a/sparse/etc/sensorfw/sensord.conf.d/90-devkit.conf
+++ b/sparse/etc/sensorfw/sensord.conf.d/90-devkit.conf
@@ -1,0 +1,30 @@
+[accelerometer]
+input_match=mpu6050
+intervals = "200=>2000"
+default_interval=500
+transformation_matrix = "0,1,0,1,0,0,0,0,1"
+
+[als]
+input_match=stk3310
+intervals = "200=>2000"
+default_interval=500
+
+[gyroscope]
+input_match=mpu6050
+intervals = "200=>2000"
+default_interval=500
+transformation_matrix = "0,1,0,1,0,0,0,0,1"
+
+[magnetometer]
+input_match=lis3mdl
+intervals = "200=>2000"
+default_interval=500
+
+[lis3mdl]
+scale = 1.0
+
+[proximity]
+input_match=stk3310
+intervals = "200=>2000"
+default_interval=500
+threshold=250


### PR DESCRIPTION
This PR adds the `sensorfw` configuration to enable the following sensors:

- `mpu6050` acceleration/rotation and gyroscope sensor
- `stk3310` magnetometer sensor
- `lis3mdl` light and proximity sensor

**Progress**

- [x] Accelerometer sensor
- [x] Rotation sensor
- [x] Light sensor: must shine a light on the back of the PCB to test
- [x] Proximity sensor
- [x] Gyroscope sensor
- [x] Magnetometer sensor

⚠️ You need our forked variant of `sensorfw` to run this: https://github.com/sailfish-on-dontbeevil/sensorfw which includes a cleaned up debug log for `iioadaptor` and some fixes by Elros34.