### PR TITLE
[config] Mount boot partition to allow kernel updates

### DIFF
--- a/sparse/etc/systemd/system/basic.target.wants/boot.mount
+++ b/sparse/etc/systemd/system/basic.target.wants/boot.mount
@@ -1,0 +1,1 @@
+sparse/lib/systemd/system/boot.mount

--- a/sparse/lib/systemd/system/boot.mount
+++ b/sparse/lib/systemd/system/boot.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description=Mount boot partition
+
+[Mount]
+What=/dev/mmcblk0p1
+Where=/boot
+Type=ext4
+Options=defaults,noatime
+
+[Install]
+WantedBy=local-fs.target


### PR DESCRIPTION
Use `systemd` to mount the `boot` partition under `/boot`. When updating the kernel package, the kernel will be updated on the right partition. Without this patch, the kernel is updated in the `/boot` directory. However, U-boot boots the kernel using the `boot` partition (which uses the old kernel).